### PR TITLE
Marshal json

### DIFF
--- a/field/bool.go
+++ b/field/bool.go
@@ -12,7 +12,7 @@ import (
 type Bool struct {
 	Bool   bool
 	shadow bool
-	valid  bool
+	Valid  bool
 	ShadowInit
 }
 
@@ -24,7 +24,7 @@ func (b *Bool) Scan(value interface{}) error {
 	if tmp.Valid == false {
 		return errors.New("Value should be a bool and not nil")
 	}
-	b.valid = true
+	b.Valid = true
 	b.Bool = tmp.Bool
 
 	b.DoInit(func() {
@@ -36,7 +36,7 @@ func (b *Bool) Scan(value interface{}) error {
 
 // Value return the value of this field
 func (b Bool) Value() (driver.Value, error) {
-	if b.valid == false {
+	if b.Valid == false {
 		return nil, errors.New("Invalid Value set")
 	}
 	return b.Bool, nil
@@ -52,13 +52,18 @@ func (b Bool) ShadowValue() (driver.Value, error) {
 }
 
 // IsDirty if the shadow value does not match the field value
-func (b *Bool) IsDirty() bool {
+func (b Bool) IsDirty() bool {
 	return b.Bool != b.shadow
 }
 
 // MarshalJSON Marshal just the value of Bool
 func (b Bool) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.Bool)
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler
+func (b *Bool) UnmarshalJSON(data []byte) error {
+	return b.Scan(string(data))
 }
 
 // NullBool that can be nil
@@ -102,4 +107,14 @@ func (nb NullBool) ShadowValue() (driver.Value, error) {
 		return nb.shadow.Value()
 	}
 	return nil, errors.New("Shadow Wasn't Created")
+}
+
+// MarshalJSON Marshal just the value of Bool
+func (nb NullBool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(nb.Bool)
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler
+func (nb NullBool) UnmarshalJSON(data []byte) error {
+	return nb.Scan(data)
 }

--- a/field/bool.go
+++ b/field/bool.go
@@ -115,6 +115,6 @@ func (nb NullBool) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements encoding/json Unmarshaler
-func (nb NullBool) UnmarshalJSON(data []byte) error {
+func (nb *NullBool) UnmarshalJSON(data []byte) error {
 	return nb.Scan(data)
 }

--- a/field/bool_test.go
+++ b/field/bool_test.go
@@ -246,4 +246,21 @@ func TestNullBool(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
+
+	Convey("MarshalJSON", t, func() {
+		s := NullBool{}
+		s.Scan(true)
+		data, err := json.Marshal(s)
+		So(err, ShouldBeNil)
+		So(string(data), ShouldEqual, "true")
+	})
+
+	Convey("UnmarshalJSON", t, func() {
+		s := NullBool{}
+		err := s.UnmarshalJSON([]byte("true"))
+		So(err, ShouldBeNil)
+		v, err := s.Value()
+		So(err, ShouldBeNil)
+		So(v, ShouldEqual, true)
+	})
 }

--- a/field/bool_test.go
+++ b/field/bool_test.go
@@ -16,6 +16,16 @@ func TestBool(t *testing.T) {
 			So(s.Bool, ShouldEqual, true)
 			So(s.shadow, ShouldEqual, true)
 		})
+		Convey("Scan should accept string", func() {
+			s := Bool{}
+			s.Scan("true")
+			So(s.Bool, ShouldEqual, true)
+		})
+		Convey("Scan should accept byte", func() {
+			s := Bool{}
+			s.Scan([]byte("true"))
+			So(s.Bool, ShouldEqual, true)
+		})
 		Convey("secondary Scan should not update shadow", func() {
 
 			s := &Bool{}
@@ -117,8 +127,18 @@ func TestBool(t *testing.T) {
 	Convey("MarshalJSON", t, func() {
 		s := Bool{}
 		s.Scan(true)
-		data, _ := json.Marshal(s)
+		data, err := json.Marshal(s)
+		So(err, ShouldBeNil)
 		So(string(data), ShouldEqual, "true")
+	})
+
+	Convey("UnmarshalJSON", t, func() {
+		s := Bool{}
+		err := s.UnmarshalJSON([]byte("true"))
+		So(err, ShouldBeNil)
+		v, err := s.Value()
+		So(err, ShouldBeNil)
+		So(v, ShouldEqual, true)
 	})
 }
 

--- a/field/int64.go
+++ b/field/int64.go
@@ -12,7 +12,7 @@ import (
 type Int64 struct {
 	Int64  int64
 	shadow int64
-	valid  bool
+	Valid  bool
 	ShadowInit
 }
 
@@ -25,7 +25,7 @@ func (i *Int64) Scan(value interface{}) error {
 		// TODO: maybe nil should be simply allowed to be empty int64?
 		return errors.New("Value should be a int64 and not nil")
 	}
-	i.valid = true
+	i.Valid = true
 	i.Int64 = tmp.Int64
 
 	i.DoInit(func() {
@@ -37,7 +37,7 @@ func (i *Int64) Scan(value interface{}) error {
 
 // Value return the value of this field
 func (i Int64) Value() (driver.Value, error) {
-	if i.valid == false {
+	if i.Valid == false {
 		return nil, errors.New("Value was not set or was set to nil")
 	}
 	return i.Int64, nil
@@ -60,6 +60,11 @@ func (i *Int64) IsDirty() bool {
 // MarshalJSON Marshal just the value of Int64
 func (i Int64) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.Int64)
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler
+func (i Int64) UnmarshalJSON(data []byte) error {
+	return i.Scan(data)
 }
 
 // NullInt64 that can be nil
@@ -103,4 +108,14 @@ func (ni NullInt64) ShadowValue() (driver.Value, error) {
 		return ni.shadow.Value()
 	}
 	return nil, errors.New("Shadow Wasn't Created")
+}
+
+// MarshalJSON Marshal just the value of Int64
+func (ni NullInt64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ni.Int64)
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler
+func (ni NullInt64) UnmarshalJSON(data []byte) error {
+	return ni.Scan(data)
 }

--- a/field/int64.go
+++ b/field/int64.go
@@ -63,7 +63,7 @@ func (i Int64) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements encoding/json Unmarshaler
-func (i Int64) UnmarshalJSON(data []byte) error {
+func (i *Int64) UnmarshalJSON(data []byte) error {
 	return i.Scan(data)
 }
 
@@ -116,6 +116,6 @@ func (ni NullInt64) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements encoding/json Unmarshaler
-func (ni NullInt64) UnmarshalJSON(data []byte) error {
+func (ni *NullInt64) UnmarshalJSON(data []byte) error {
 	return ni.Scan(data)
 }

--- a/field/int64_test.go
+++ b/field/int64_test.go
@@ -112,6 +112,15 @@ func TestInt64(t *testing.T) {
 		data, _ := json.Marshal(s)
 		So(string(data), ShouldEqual, "1234")
 	})
+
+	Convey("UnmarshalJSON", t, func() {
+		s := Int64{}
+		err := s.UnmarshalJSON([]byte("5612"))
+		So(err, ShouldBeNil)
+		v, err := s.Value()
+		So(err, ShouldBeNil)
+		So(v, ShouldEqual, int64(5612))
+	})
 }
 
 func TestNullInt64(t *testing.T) {
@@ -217,5 +226,21 @@ func TestNullInt64(t *testing.T) {
 			So(value, ShouldEqual, 1234)
 			So(err, ShouldBeNil)
 		})
+	})
+
+	Convey("MarshalJSON", t, func() {
+		s := NullInt64{}
+		s.Scan(1234)
+		data, _ := json.Marshal(s)
+		So(string(data), ShouldEqual, "1234")
+	})
+
+	Convey("UnmarshalJSON", t, func() {
+		s := NullInt64{}
+		err := s.UnmarshalJSON([]byte("5612"))
+		So(err, ShouldBeNil)
+		v, err := s.Value()
+		So(err, ShouldBeNil)
+		So(v, ShouldEqual, int64(5612))
 	})
 }

--- a/field/string.go
+++ b/field/string.go
@@ -12,6 +12,7 @@ import (
 type String struct {
 	String string
 	shadow string
+	Valid  bool
 	ShadowInit
 }
 
@@ -25,7 +26,7 @@ func (s *String) Scan(value interface{}) error {
 		return errors.New("norm.field.String: value should be a string and not nil")
 	}
 	s.String = tmp.String
-
+	s.Valid = true
 	s.DoInit(func() {
 		s.shadow = tmp.String
 	})
@@ -35,6 +36,9 @@ func (s *String) Scan(value interface{}) error {
 
 // Value return the value of this field
 func (s String) Value() (driver.Value, error) {
+	if s.Valid == false {
+		return nil, errors.New("Value was not set or was set to nil")
+	}
 	return s.String, nil
 }
 
@@ -55,6 +59,11 @@ func (s *String) IsDirty() bool {
 // MarshalJSON Marshal just the value of String
 func (s String) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String)
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler
+func (s String) UnmarshalJSON(data []byte) error {
+	return s.Scan(data)
 }
 
 // NullString string that allows nil
@@ -98,4 +107,14 @@ func (ns NullString) ShadowValue() (driver.Value, error) {
 		return ns.shadow.Value()
 	}
 	return nil, errors.New("Shadow Wasn't Created")
+}
+
+// MarshalJSON Marshal just the value of String
+func (ns NullString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ns.String)
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler
+func (ns NullString) UnmarshalJSON(data []byte) error {
+	return ns.Scan(data)
 }

--- a/field/string.go
+++ b/field/string.go
@@ -62,7 +62,7 @@ func (s String) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements encoding/json Unmarshaler
-func (s String) UnmarshalJSON(data []byte) error {
+func (s *String) UnmarshalJSON(data []byte) error {
 	return s.Scan(data)
 }
 
@@ -115,6 +115,6 @@ func (ns NullString) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements encoding/json Unmarshaler
-func (ns NullString) UnmarshalJSON(data []byte) error {
+func (ns *NullString) UnmarshalJSON(data []byte) error {
 	return ns.Scan(data)
 }

--- a/field/string_test.go
+++ b/field/string_test.go
@@ -38,13 +38,13 @@ func TestString(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
-		Convey("should return empty string on scanned nil", func() {
+		Convey("should return err on scanned nil", func() {
 			s := &String{}
 			s.Scan(nil)
 
 			value, err := s.Value()
-			So(value, ShouldEqual, "")
-			So(err, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(value, ShouldBeNil)
 		})
 	})
 

--- a/field/string_test.go
+++ b/field/string_test.go
@@ -120,6 +120,15 @@ func TestString(t *testing.T) {
 		data, _ := json.Marshal(s)
 		So(string(data), ShouldEqual, "\"Cat\"")
 	})
+
+	Convey("UnmarshalJSON", t, func() {
+		s := String{}
+		err := s.UnmarshalJSON([]byte("i am the string"))
+		So(err, ShouldBeNil)
+		v, err := s.Value()
+		So(err, ShouldBeNil)
+		So(v, ShouldEqual, "i am the string")
+	})
 }
 
 func TestNullString(t *testing.T) {
@@ -225,5 +234,21 @@ func TestNullString(t *testing.T) {
 			So(value, ShouldEqual, "First")
 			So(err, ShouldBeNil)
 		})
+	})
+
+	Convey("MarshalJSON", t, func() {
+		s := NullString{}
+		s.Scan("Cat")
+		data, _ := json.Marshal(s)
+		So(string(data), ShouldEqual, "\"Cat\"")
+	})
+
+	Convey("UnmarshalJSON", t, func() {
+		s := NullString{}
+		err := s.UnmarshalJSON([]byte("i am the string"))
+		So(err, ShouldBeNil)
+		v, err := s.Value()
+		So(err, ShouldBeNil)
+		So(v, ShouldEqual, "i am the string")
 	})
 }

--- a/field/time.go
+++ b/field/time.go
@@ -65,7 +65,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements encoding/json Unmarshaler
-func (t Time) UnmarshalJSON(data []byte) error {
+func (t *Time) UnmarshalJSON(data []byte) error {
 	return t.Scan(data)
 }
 
@@ -118,6 +118,6 @@ func (nt NullTime) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements encoding/json Unmarshaler
-func (nt NullTime) UnmarshalJSON(data []byte) error {
+func (nt *NullTime) UnmarshalJSON(data []byte) error {
 	return nt.Scan(data)
 }

--- a/field/time.go
+++ b/field/time.go
@@ -12,6 +12,7 @@ import (
 type Time struct {
 	Time   time.Time
 	shadow time.Time
+	Valid  bool
 	ShadowInit
 }
 
@@ -28,7 +29,7 @@ func (t *Time) Scan(value interface{}) error {
 		return errors.New("value should be a time and not nil")
 	}
 	t.Time = tmp.Time
-
+	t.Valid = true
 	t.DoInit(func() {
 		t.shadow = tmp.Time
 	})
@@ -38,7 +39,7 @@ func (t *Time) Scan(value interface{}) error {
 
 // Value return the value of this field
 func (t Time) Value() (driver.Value, error) {
-	if t.Time.IsZero() == true {
+	if t.Time.IsZero() == true || t.Valid == false {
 		return nil, errors.New("Value was not set or was set to nil")
 	}
 	return t.Time, nil
@@ -61,6 +62,11 @@ func (t *Time) IsDirty() bool {
 // MarshalJSON Marshal just the value of Time
 func (t Time) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time)
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler
+func (t Time) UnmarshalJSON(data []byte) error {
+	return t.Scan(data)
 }
 
 // NullTime time that can be nil
@@ -104,4 +110,14 @@ func (nt NullTime) ShadowValue() (driver.Value, error) {
 		return nt.shadow.Value()
 	}
 	return nil, errors.New("Shadow Wasn't Created")
+}
+
+// MarshalJSON Marshal just the value of String
+func (nt NullTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(nt.Time)
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler
+func (nt NullTime) UnmarshalJSON(data []byte) error {
+	return nt.Scan(data)
 }

--- a/field/time_test.go
+++ b/field/time_test.go
@@ -120,6 +120,15 @@ func TestTime(t *testing.T) {
 		data, _ := json.Marshal(s)
 		So(string(data), ShouldEqual, "\"2015-01-01T12:12:12Z\"")
 	})
+
+	Convey("UnmarshalJSON", t, func() {
+		s := Time{}
+		err := s.UnmarshalJSON([]byte("2015-01-01 12:12:12"))
+		So(err, ShouldBeNil)
+		v, err := s.Value()
+		So(err, ShouldBeNil)
+		So(v.(time.Time).String(), ShouldEqual, "2015-01-01 12:12:12 +0000 UTC")
+	})
 }
 
 func TestNullTime(t *testing.T) {
@@ -225,5 +234,21 @@ func TestNullTime(t *testing.T) {
 			So(timeValue.Format(timeFormat), ShouldEqual, timeA)
 			So(err, ShouldBeNil)
 		})
+	})
+
+	Convey("MarshalJSON", t, func() {
+		s := NullTime{}
+		s.Scan(timeA)
+		data, _ := json.Marshal(s)
+		So(string(data), ShouldEqual, "\"2015-01-01T12:12:12Z\"")
+	})
+
+	Convey("UnmarshalJSON", t, func() {
+		s := NullTime{}
+		err := s.UnmarshalJSON([]byte("2015-01-01 12:12:12"))
+		So(err, ShouldBeNil)
+		v, err := s.Value()
+		So(err, ShouldBeNil)
+		So(v.(time.Time).String(), ShouldEqual, "2015-01-01 12:12:12 +0000 UTC")
 	})
 }


### PR DESCRIPTION
Fixes the unmarshal interface needing a pointer to work, turns the encoding/json always uses a pointer for this operation, which makes sense... dur.

cc @kevpie 

closes #10 
