### PR TITLE
Embed support

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -9,9 +9,8 @@ import:
   - package: github.com/go-sql-driver/mysql
     repo:    https://github.com/go-sql-driver/mysql
     vcs:     git
-  - package: github.com/smartystreets/goconvey
-    repo:    https://github.com/smartystreets/goconvey
-    vcs:     git
-    subpackages:
-      - /convey
   - package: gopkg.in/guregu/null.v2
+  - package: github.com/kisielk/sqlstruct
+  - package: github.com/smartystreets/goconvey
+  - package: github.com/smartystreets/assertions
+    flatten: true

--- a/model.go
+++ b/model.go
@@ -74,21 +74,20 @@ func ModelFields(model Model) field.Names {
 	if modelType.Elem().Kind() != reflect.Struct {
 		panic("Expected Model to be a Ptr to a Struct")
 	}
-	fields := make(field.Names, 0)
 
-	fields = append(fields, modelFields(model)...)
-
-	return fields
+	return modelFields(model)
 }
 
 func modelFields(model interface{}) field.Names {
 	fields := make(field.Names, 0)
 
+	// Value of model
 	ifv := reflect.ValueOf(model)
 	if ifv.Kind() == reflect.Ptr {
 		ifv = ifv.Elem()
 	}
 
+	// Type of Model
 	itf := reflect.TypeOf(model)
 	if itf.Kind() == reflect.Ptr {
 		itf = itf.Elem()
@@ -96,11 +95,14 @@ func modelFields(model interface{}) field.Names {
 
 	for i := 0; i < itf.NumField(); i++ {
 		v := ifv.Field(i)
-		t := itf.Field(i)
+
 		if v.CanAddr() == true && v.Addr().Type().Implements(fieldType) == true {
 			fields = append(fields, field.Name(itf.Field(i).Name))
-		} else if t.Anonymous == true && v.CanAddr() && v.Kind() == reflect.Struct {
-			fields = append(fields, modelFields(v.Addr().Interface())...)
+		} else {
+			t := itf.Field(i)
+			if t.Anonymous == true && v.CanAddr() == true && v.Kind() == reflect.Struct {
+				fields = append(fields, modelFields(v.Addr().Interface())...)
+			}
 		}
 	}
 

--- a/model_test.go
+++ b/model_test.go
@@ -71,11 +71,6 @@ func TestModel(t *testing.T) {
 				So(len(fields), ShouldEqual, 3)
 			})
 
-			SkipConvey("On Struct", func() {
-				m := &MockModel{}
-				So(func() { ModelFields(m) }, ShouldPanic)
-			})
-
 			Convey("With embedded struct", func() {
 				fields := ModelFields(modelWithEmbedded)
 				So(fields, ShouldContain, field.Name("Id"))
@@ -103,6 +98,15 @@ func TestModel(t *testing.T) {
 				rawModelField, err := ModelGetField(model, "NotAField")
 				So(rawModelField, ShouldBeNil)
 				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Field from Embedded struct", func() {
+				modelWithEmbedded.Id.Scan("12")
+				idField, err := ModelGetField(modelWithEmbedded, "Id")
+				So(err, ShouldBeNil)
+				f, ok := idField.(*field.NullString)
+				So(ok, ShouldBeTrue)
+				So(f.String, ShouldEqual, "12")
 			})
 		})
 

--- a/model_test.go
+++ b/model_test.go
@@ -15,6 +15,12 @@ type MockModel struct {
 	Ignore    string
 }
 
+type MockModelEmbedded struct {
+	MockModel
+	Created  field.Time
+	Modified field.Time
+}
+
 func (*MockModel) TableName() string {
 	return "mocks"
 }
@@ -54,6 +60,8 @@ func TestModel(t *testing.T) {
 		model.Id.Scan("1")
 		model.FirstName.Scan("Mock")
 
+		modelWithEmbedded := &MockModelEmbedded{}
+
 		Convey("ModelFields", func() {
 			Convey("On Ptr to Struct", func() {
 				fields := ModelFields(model)
@@ -67,6 +75,17 @@ func TestModel(t *testing.T) {
 				m := &MockModel{}
 				So(func() { ModelFields(m) }, ShouldPanic)
 			})
+
+			Convey("With embedded struct", func() {
+				fields := ModelFields(modelWithEmbedded)
+				So(fields, ShouldContain, field.Name("Id"))
+				So(fields, ShouldContain, field.Name("FirstName"))
+				So(fields, ShouldContain, field.Name("Org"))
+				So(fields, ShouldContain, field.Name("Created"))
+				So(fields, ShouldContain, field.Name("Modified"))
+				So(len(fields), ShouldEqual, 5)
+			})
+
 		})
 
 		Convey("ModelGetField", func() {


### PR DESCRIPTION
Support to get fields on embedded structs that have norm.Field fields.

Allows creating a generic struct for common fields, and other sibling patterns.
