### PR TITLE
Added Tx struct and norm.Begin function

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -63,3 +63,17 @@ type session struct {
 func (s session) Connection() Connection {
 	return s.connection
 }
+
+type Tx struct {
+	*dbr.Tx
+	connection Connection
+}
+
+func (t Tx) Connection() Connection {
+	return t.connection
+}
+
+func Begin(s Session) (*Tx, error) {
+	tx, err := s.Begin()
+	return &Tx{tx, s.Connection()}, err
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -25,3 +25,5 @@ func TestConnection(t *testing.T) {
 		})
 	})
 }
+
+var tx Session = Tx{} //ensure Tx implements Session

--- a/connection_test.go
+++ b/connection_test.go
@@ -26,4 +26,5 @@ func TestConnection(t *testing.T) {
 	})
 }
 
-var tx Session = Tx{} //ensure Tx implements Session
+var _ Session = &tx{} //ensure tx implements Session
+var _ Tx = &tx{}      //ensure tx implements Tx


### PR DESCRIPTION
Needed Transactions to implement Session in order to make them compatible with norm. Added Tx struct and norm.Begin(s Session). This is linked to solving issue picatic/go-api#138 @interlock 
