### PR TITLE
Fixed ModelValidate to return a true nil when no errors

### DIFF
--- a/field/string.go
+++ b/field/string.go
@@ -143,6 +143,4 @@ func (ns *NullString) UnmarshalJSON(data []byte) error {
 		return ns.Scan(s.String)
 	}
 	return ns.Scan(nil)
-
-	return nil
 }

--- a/model.go
+++ b/model.go
@@ -290,5 +290,9 @@ func ModelValidate(sess Session, model Model, fields field.Names) error {
 			return nil
 		}
 	}
-	return validators.Validate(sess, model, fields)
+	err := validators.Validate(sess, model, fields)
+	if err == nil { // a ptr to a struct cast into an interface is no longer really nil
+		return nil
+	}
+	return err
 }

--- a/valid_test.go
+++ b/valid_test.go
@@ -113,12 +113,10 @@ func TestValidator(t *testing.T) {
 		})
 
 		Convey("error passed", func() {
-			Convey("nil error follows through", func() {
-				m := &MockModel{}
-				m.FirstName.Scan("Not Pete")
-				err := ModelValidate(normConn.NewSession(nil), m, nil)
-				So(err, ShouldNotBeNil)
-			})
+			m := &MockModel{}
+			m.FirstName.Scan("Not Pete")
+			err := ModelValidate(normConn.NewSession(nil), m, nil)
+			So(err, ShouldNotBeNil)
 		})
 	})
 

--- a/valid_test.go
+++ b/valid_test.go
@@ -103,7 +103,23 @@ func TestValidator(t *testing.T) {
 	})
 
 	Convey("ModelValidator", t, func() {
+		normConn := NewConnection(nil, "picatic", nil)
+		Convey("nil error follows through", func() {
+			m := &MockModel{}
+			m.FirstName.Scan("Pete")
+			err := ModelValidate(normConn.NewSession(nil), m, nil)
+			So(err, ShouldBeNil)
+			So(err == nil, ShouldBeTrue)
+		})
 
+		Convey("error passed", func() {
+			Convey("nil error follows through", func() {
+				m := &MockModel{}
+				m.FirstName.Scan("Not Pete")
+				err := ModelValidate(normConn.NewSession(nil), m, nil)
+				So(err, ShouldNotBeNil)
+			})
+		})
 	})
 
 	Convey("FieldValidator", t, func() {


### PR DESCRIPTION
removed dead code on string field, fixed ModelValidate to catch nil ptr to struct as error interface ptr to nil. Which fails a err != nil check. Tests added to confirm
