### PR TITLE
updated glide.yaml and now using null.v3 package

### DIFF
--- a/field/bool.go
+++ b/field/bool.go
@@ -3,7 +3,7 @@ package field
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"gopkg.in/guregu/null.v2"
+	"gopkg.in/guregu/null.v3"
 )
 
 // Bool that cannot be nil

--- a/field/float64.go
+++ b/field/float64.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"gopkg.in/guregu/null.v2"
+	"gopkg.in/guregu/null.v3"
 )
 
 // Float64 cannot be nil

--- a/field/int64.go
+++ b/field/int64.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
-	"gopkg.in/guregu/null.v2"
+	"gopkg.in/guregu/null.v3"
 )
 
 // Int64 that cannot be nil

--- a/field/string.go
+++ b/field/string.go
@@ -4,7 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
-	"gopkg.in/guregu/null.v2"
+	"gopkg.in/guregu/null.v3"
 )
 
 // String field type, does not allow nil

--- a/field/time.go
+++ b/field/time.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gopkg.in/guregu/null.v2"
+	"gopkg.in/guregu/null.v3"
 	"time"
 )
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/picatic/norm
 import:
   - package: github.com/gocraft/dbr
+    ref:     1.1
   - package: github.com/AlekSi/reflector
   - package: github.com/DATA-DOG/go-sqlmock
     ref:     v1.0.0
@@ -9,7 +10,7 @@ import:
   - package: github.com/go-sql-driver/mysql
     repo:    https://github.com/go-sql-driver/mysql
     vcs:     git
-  - package: gopkg.in/guregu/null.v2
+  - package: gopkg.in/guregu/null.v3
   - package: github.com/kisielk/sqlstruct
   - package: github.com/smartystreets/goconvey
   - package: github.com/smartystreets/assertions


### PR DESCRIPTION
dbr has made updates since so this fixes dbr to a ref number. Guregu null has been updated to a version 3, version 2 was causing problems with Scanning empty strings
