### PR TITLE
fixed NullTime.Value()

### DIFF
--- a/field/time.go
+++ b/field/time.go
@@ -171,6 +171,9 @@ func (nt NullTime) Value() (driver.Value, error) {
 	if nt.validNull {
 		return nil, nil
 	}
+	if nt.Time.IsZero() {
+		return nil, nil
+	}
 	return nt.Time, nil
 }
 


### PR DESCRIPTION
This fixes inserting zero values into the database when using NullTimes
