### PR TITLE
add MapSetFields with tests

### DIFF
--- a/model.go
+++ b/model.go
@@ -348,3 +348,32 @@ func MapFields(originModel Model, destinationModel Model, mappings map[field.Nam
 		destinationField.Scan(originField)
 	}
 }
+
+//MapSetFields makes a copy from a origin model to a destination model fields that are set with the same name or
+//provided by a mapping table
+func MapSetFields(originModel Model, destinationModel Model, mappings map[field.Name]field.Name) {
+	originFieldNames := ModelFields(originModel)
+	for _, originFieldName := range originFieldNames {
+		var (
+			destinationFieldName field.Name
+			ok                   bool
+		)
+
+		if destinationFieldName, ok = mappings[originFieldName]; !ok {
+			destinationFieldName = originFieldName
+		}
+
+		originField, err := ModelGetField(originModel, originFieldName)
+		if err == NameNotFoundErr {
+			continue
+		}
+
+		if originField.IsSet() {
+			destinationField, err := ModelGetField(destinationModel, destinationFieldName)
+			if err == NameNotFoundErr {
+				continue
+			}
+			destinationField.Scan(originField)
+		}
+	}
+}

--- a/model_test.go
+++ b/model_test.go
@@ -300,5 +300,31 @@ func TestModel(t *testing.T) {
 				So(destModel.Org.String, ShouldEqual, originModel.Org.String)
 			})
 		})
+
+		Convey("MapSetFields", func() {
+			originModel := &MockModel{}
+			destModel := &MockModelDTO{}
+
+			//not scanning id
+			originModel.FirstName.Scan("Joe")
+			originModel.Org.Scan("Picatic")
+
+			Convey("Without mapping", func() {
+				MapFields(originModel, destModel, map[field.Name]field.Name{})
+				So(destModel.ModelId.String, ShouldEqual, "")
+				So(destModel.FirstName.String, ShouldEqual, originModel.FirstName.String)
+				So(destModel.Org.String, ShouldEqual, originModel.Org.String)
+			})
+
+			Convey("With mapping", func() {
+				MapFields(originModel, destModel, map[field.Name]field.Name{"Id": "ModelId"})
+
+				So(originModel.Id.IsSet(), ShouldBeFalse)
+				So(destModel.ModelId.IsSet(), ShouldBeFalse)
+
+				So(destModel.FirstName.String, ShouldEqual, originModel.FirstName.String)
+				So(destModel.Org.String, ShouldEqual, originModel.Org.String)
+			})
+		})
 	})
 }


### PR DESCRIPTION
adds MapSetFields. @cleitonmarx I added tests for it but what I was thinking before was that when Scanning a field that has not been scanned scan should return an error. I mainly have a problem with us not handling scan errors anywhere in our code it feels messy. Value should also return an error if the field has not been initialized. The fact though is we never return errors (even though we should) and so this isn't going to cause an error.
